### PR TITLE
Add Esc to abort agent runs, clear input, or exit when idle

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -35,6 +35,7 @@ export function listTools(): ToolDescriptor[] {
 export async function* runAgent(
   history: ModelMessage[],
   userInput: string,
+  options?: { signal?: AbortSignal },
 ): AsyncGenerator<AgentEvent> {
   const messages: ModelMessage[] = [...history, { role: 'user', content: userInput }];
 
@@ -52,9 +53,11 @@ export async function* runAgent(
       tools: mergedTools,
       stopWhen: stepCountIs(100),
       temperature: 0.2,
+      abortSignal: options?.signal,
     });
 
     for await (const part of result.fullStream) {
+      if (options?.signal?.aborted) break;
       const ev = normalizePart(part as Parameters<typeof normalizePart>[0]);
       if (ev) yield ev;
     }

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -52,7 +52,21 @@ export function App() {
       else if (ch === 'n' || ch === 'N' || key.escape) decide('no');
       return;
     }
-    if (key.escape && !input) exit();
+    // Esc precedence: abort while busy → clear pending input → exit when idle.
+    if (key.escape) {
+      if (stream.busy) {
+        stream.abort();
+        stream.setBusy(false);
+        stream.setActive('');
+        stream.setActiveTool(null);
+        return;
+      }
+      if (input) {
+        setInput('');
+        return;
+      }
+      exit();
+    }
   });
 
   const handleInputKey = (_ch: string, key: KeyMeta): boolean => {
@@ -67,7 +81,10 @@ export function App() {
     }
     if (key.tab) {
       const choice = suggestions[suggestionIndex];
-      if (choice) setInput(choice.insert);
+      if (choice) {
+        setInput(choice.insert);
+        setSuggestionIndex(0);
+      }
       return true;
     }
     return false;

--- a/src/cli/components/MultilineInput.tsx
+++ b/src/cli/components/MultilineInput.tsx
@@ -54,6 +54,219 @@ export function MultilineInput({
 }: MultilineInputProps) {
   const [cursor, setCursor] = useState(value.length);
 
+  // Re-pin cursor if the parent shrinks the value out from under us,
+  // or if the new value is longer (e.g. autocomplete inserted text).
+  if (cursor > value.length) setCursor(value.length);
+  else if (value.length > cursor) setCursor(value.length);
+
+  useInput((input, key) => {
+    if (disabled) return;
+
+    if (onKey?.(input, key as KeyMeta)) return;
+
+    // Submit vs newline. Shift+Enter, Alt+Enter, Ctrl+J → newline. Plain Enter → submit.
+    if (key.return) {
+      const isNewline = key.shift || key.meta || (key.ctrl && input === '\n');
+      if (isNewline) {
+        const next = value.slice(0, cursor) + '\n' + value.slice(cursor);
+        onChange(next);
+        setCursor(cursor + 1);
+        return;
+      }
+      onSubmit(value);
+      return;
+    }
+
+    if (key.ctrl && input === 'j') {
+      const next = value.slice(0, cursor) + '\n' + value.slice(cursor);
+      onChange(next);
+      setCursor(cursor + 1);
+      return;
+    }
+
+    if (key.backspace || key.delete) {
+      if (cursor === 0) return;
+      const next = value.slice(0, cursor - 1) + value.slice(cursor);
+      onChange(next);
+      setCursor(cursor - 1);
+      return;
+    }
+
+    if (key.leftArrow) {
+      setCursor(Math.max(0, cursor - 1));
+      return;
+    }
+    if (key.rightArrow) {
+      setCursor(Math.min(value.length, cursor + 1));
+      return;
+    }
+    if (key.upArrow) {
+      setCursor(moveCursorVertically(value, cursor, -1));
+      return;
+    }
+    if (key.downArrow) {
+      setCursor(moveCursorVertically(value, cursor, +1));
+      return;
+    }
+
+    if (key.ctrl && input === 'a') {
+      setCursor(startOfLine(value, cursor));
+      return;
+    }
+    if (key.ctrl && input === 'e') {
+      setCursor(endOfLine(value, cursor));
+      return;
+    }
+    if (key.ctrl && input === 'u') {
+      const start = startOfLine(value, cursor);
+      onChange(value.slice(0, start) + value.slice(cursor));
+      setCursor(start);
+      return;
+    }
+
+    if (input && !key.ctrl && !key.meta) {
+      const next = value.slice(0, cursor) + input + value.slice(cursor);
+      onChange(next);
+      setCursor(cursor + input.length);
+    }
+  });
+
+  return <RenderedInput value={value} cursor={cursor} placeholder={placeholder} />;
+}
+
+function startOfLine(value: string, cursor: number): number {
+  const prev = value.lastIndexOf('\n', cursor - 1);
+  return prev === -1 ? 0 : prev + 1;
+}
+
+function endOfLine(value: string, cursor: number): number {
+  const next = value.indexOf('\n', cursor);
+  return next === -1 ? value.length : next;
+}
+
+function moveCursorVertically(value: string, cursor: number, dir: -1 | 1): number {
+  const lineStart = startOfLine(value, cursor);
+  const col = cursor - lineStart;
+
+  if (dir < 0) {
+    if (lineStart === 0) return 0;
+    const prevLineStart = startOfLine(value, lineStart - 1);
+    const prevLineEnd = lineStart - 1;
+    return Math.min(prevLineEnd, prevLineStart + col);
+  }
+  const nextLineStart = endOfLine(value, cursor) + 1;
+  if (nextLineStart > value.length) return value.length;
+  const nextLineEnd = endOfLine(value, nextLineStart);
+  return Math.min(nextLineEnd, nextLineStart + col);
+}
+
+function RenderedInput({
+  value,
+  cursor,
+  placeholder,
+}: {
+  value: string;
+  cursor: number;
+  placeholder?: string;
+}) {
+  if (!value && placeholder) {
+    return (
+      <Box flexDirection="column">
+        <Text>
+          <Text inverse> </Text>
+          <Text dimColor>{placeholder}</Text>
+        </Text>
+      </Box>
+    );
+  }
+
+  // Insert a visible cursor block by inverting one character. End-of-buffer is
+  // a trailing inverted space so the user can see where they're typing.
+  const before = value.slice(0, cursor);
+  const at = value.slice(cursor, cursor + 1);
+  const after = value.slice(cursor + 1);
+
+  const lines: React.ReactNode[] = [];
+  const beforeLines = before.split('\n');
+  const lastBefore = beforeLines.pop() ?? '';
+  beforeLines.forEach((l, i) => lines.push(<Text key={`b${i}`}>{l || ' '}</Text>));
+
+  const afterLines = (at + after).split('\n');
+  const firstAfter = afterLines.shift() ?? '';
+  const cursorChar = at === '\n' || at === '' ? ' ' : at;
+  const restOfFirstAfter = at === '\n' ? '' : firstAfter.slice(1);
+
+  lines.push(
+    <Text key="cursor">
+      {lastBefore}
+      <Text inverse>{cursorChar}</Text>
+      {restOfFirstAfter}
+    </Text>,
+  );
+
+  if (at === '\n') {
+    afterLines.unshift('');
+  }
+  afterLines.forEach((l, i) => lines.push(<Text key={`a${i}`}>{l || ' '}</Text>));
+
+  return <Box flexDirection="column">{lines}</Box>;
+}
+import React, { useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+
+interface MultilineInputProps {
+  value: string;
+  onChange: (next: string) => void;
+  onSubmit: (final: string) => void;
+  /** Optional intercept; return true if the key was consumed and default handling should be skipped. */
+  onKey?: (input: string, key: KeyMeta) => boolean;
+  placeholder?: string;
+  /** When true, the input is read-only (e.g. while busy). */
+  disabled?: boolean;
+}
+
+export interface KeyMeta {
+  upArrow: boolean;
+  downArrow: boolean;
+  leftArrow: boolean;
+  rightArrow: boolean;
+  return: boolean;
+  escape: boolean;
+  ctrl: boolean;
+  shift: boolean;
+  meta: boolean;
+  tab: boolean;
+  backspace: boolean;
+  delete: boolean;
+}
+
+/**
+ * A small multiline text input for Ink.
+ *
+ * Keybindings:
+ *   Enter           submit
+ *   Shift+Enter     newline    (terminals that send \r\n on shift-enter)
+ *   Alt+Enter       newline    (most terminals — works without xterm bracketed-paste hack)
+ *   Ctrl+J          newline    (universal fallback)
+ *   ←/→             move cursor in line
+ *   ↑/↓             move cursor between lines
+ *   Backspace       delete left
+ *   Ctrl+A / Ctrl+E start / end of line
+ *   Ctrl+U          delete to start of line
+ *
+ * Pasted bursts come through `useInput` as a single chunk including newlines —
+ * we honour any \n in the chunk verbatim, so multi-line paste just works.
+ */
+export function MultilineInput({
+  value,
+  onChange,
+  onSubmit,
+  onKey,
+  placeholder,
+  disabled,
+}: MultilineInputProps) {
+  const [cursor, setCursor] = useState(value.length);
+
   // Re-pin cursor if the parent shrinks the value out from under us.
   if (cursor > value.length) setCursor(value.length);
 

--- a/src/cli/hooks/useAgentStream.ts
+++ b/src/cli/hooks/useAgentStream.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import type { ModelMessage } from 'ai';
 import { runAgent, type TokenUsage } from '../../agent/index.js';
 import { saveSession, type Session } from '../../session/index.js';
@@ -28,6 +28,9 @@ interface UseAgentStreamResult {
   totals: UsageTotals;
   lastUsage: TokenUsage | null;
   send: (text: string) => Promise<void>;
+  abort: () => void;
+  setActive: (a: string) => void;
+  setActiveTool: (t: ActiveTool | null) => void;
 }
 
 function errorMessage(e: unknown): string {
@@ -44,6 +47,7 @@ export function useAgentStream(args: UseAgentStreamArgs): UseAgentStreamResult {
   const [tick, setTick] = useState(0);
   const [totals, setTotals] = useState<UsageTotals>({ input: 0, output: 0, turns: 0 });
   const [lastUsage, setLastUsage] = useState<TokenUsage | null>(null);
+  const abortRef = React.useRef<() => void>(() => {});
 
   const appendLines = useCallback((...newLines: Line[]) => {
     if (newLines.length === 0) return;
@@ -65,8 +69,23 @@ export function useAgentStream(args: UseAgentStreamArgs): UseAgentStreamResult {
         setActive('');
       };
 
+      const controller = new AbortController();
+      let aborted = false;
+
+      // Expose abort
+      abortRef.current = () => {
+        if (!aborted) {
+          aborted = true;
+          controller.abort();
+        }
+      };
+
       try {
-        for await (const ev of runAgent(history, text)) {
+        for await (const ev of runAgent(history, text, { signal: controller.signal })) {
+          if (aborted) {
+            appendLines({ kind: 'error', text: 'aborted' });
+            break;
+          }
           if (ev.type === 'text') {
             current += ev.text ?? '';
             setActive(current);
@@ -116,7 +135,9 @@ export function useAgentStream(args: UseAgentStreamArgs): UseAgentStreamResult {
           }
         }
       } catch (e: unknown) {
-        appendLines({ kind: 'error', text: errorMessage(e) });
+        if (!aborted) {
+          appendLines({ kind: 'error', text: errorMessage(e) });
+        }
       }
       setActive('');
       setActiveTool(null);
@@ -124,6 +145,10 @@ export function useAgentStream(args: UseAgentStreamArgs): UseAgentStreamResult {
     },
     [appendLines, currentSession, cwd, history, setCurrentSession],
   );
+
+  const abort = useCallback(() => {
+    abortRef.current();
+  }, []);
 
   return {
     lines,
@@ -138,5 +163,8 @@ export function useAgentStream(args: UseAgentStreamArgs): UseAgentStreamResult {
     totals,
     lastUsage,
     send,
+    abort,
+    setActive,
+    setActiveTool,
   };
 }

--- a/src/cli/hooks/useThinkingPhrase.ts
+++ b/src/cli/hooks/useThinkingPhrase.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-const ROTATE_MS = 2400;
+const ROTATE_MS = 5000;
 
 const GENERIC = [
   'thinking…',


### PR DESCRIPTION

## Summary

  Replaces the `Ctrl+G` shortcut for cancelling agent runs with a layered `Esc` handler, and wires a real `AbortSignal` through the agent stream so
  cancellation actually stops mid-flight tool calls instead of just hiding the UI.

  ## What changed

  - **`src/agent/index.ts`** — `runAgent` now accepts `options.signal`, forwards it to `streamText` as `abortSignal`, and breaks out of `result.fullStream`
  when the signal fires.
  - **`src/cli/hooks/useAgentStream.ts`** — owns an `AbortController` per run, exposes `abort()` to the UI, and emits an `"aborted"` line on cancel.
  - **`src/cli/App.tsx`** — `Esc` precedence:
    1. agent busy → abort the run
    2. input has text → clear the buffer
    3. input empty → exit the app

    (Approval-pending `Esc` still declines, unchanged.)
  - **`src/cli/components/MultilineInput.tsx`** — re-pin the cursor when the parent grows `value` (e.g. autocomplete inserts text), not only when it
  shrinks.

  ## Why Esc over Ctrl+G

  `Esc` is the universal "stop / cancel" key in terminals, REPLs, and editors (matches Claude Code, Codex CLI, vim insert-mode exit, etc.). One keystroke,
  no chord. The precedence ordering means a stray `Esc` mid-stream aborts the run instead of killing the app — that's an upgrade over the old behavior where
   `Esc` with empty input always exited.