### PR TITLE
Codemap ghost state bug fix

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Box, Text, useApp, useInput } from 'ink';
 import type { Session } from '../session/index.js';
 import { listTools, type ToolDescriptor, resetProvider, describeProvider } from '../agent/index.js';
@@ -45,6 +45,13 @@ export function App({ firstRun = false }: AppProps) {
 
   const stream = useAgentStream({ cwd, currentSession, setCurrentSession });
   const thinkingPhrase = useThinkingPhrase(stream.busy, stream.activeTool?.name ?? null);
+  // Abort hook for long-running slash commands (e.g. /codemap build). The
+  // command registers its abort fn here; the Esc handler invokes it so the
+  // work actually stops instead of leaving a zombie loop pushing progress.
+  const commandAbortRef = useRef<(() => void) | null>(null);
+  const registerAbort = useCallback((abort: (() => void) | null) => {
+    commandAbortRef.current = abort;
+  }, []);
 
   useEffect(() => {
     setTools(listTools());
@@ -79,10 +86,19 @@ export function App({ firstRun = false }: AppProps) {
     // Esc precedence: abort while busy → clear pending input → exit when idle.
     if (key.escape) {
       if (stream.busy) {
+        // A slash command (e.g. /codemap build) registers its own abort. Fire
+        // that first so its background work actually stops; otherwise it
+        // keeps pushing progress updates and competes with the next prompt
+        // for the same provider connection.
+        if (commandAbortRef.current) {
+          commandAbortRef.current();
+          commandAbortRef.current = null;
+        }
         stream.abort();
         stream.setBusy(false);
         stream.setActive('');
         stream.setActiveTool(null);
+        setCodemapProgress(null);
         return;
       }
       if (input) {
@@ -138,6 +154,7 @@ export function App({ firstRun = false }: AppProps) {
         appendLines: stream.appendLines,
         setBusy: stream.setBusy,
         setCodemapProgress,
+        registerAbort,
         enterReconfigure,
         exit,
       },

--- a/src/cli/commands/codemap.ts
+++ b/src/cli/commands/codemap.ts
@@ -31,21 +31,30 @@ export const codemapCommand: SlashCommand = {
         return;
       }
       if (sub === 'build' || sub === 'rebuild') {
+        const controller = new AbortController();
+        ctx.registerAbort(() => controller.abort());
         ctx.setBusy(true);
-        if (sub === 'rebuild') await rebuildCodemap(ctx.cwd);
-        ctx.setCodemapProgress({ done: 0, total: 0, path: 'starting' });
-        const map = await buildSummaries(ctx.cwd, {
-          force: sub === 'rebuild',
-          onProgress: (done, total, path) =>
-            ctx.setCodemapProgress({ done, total, path }),
-        });
-        ctx.setCodemapProgress(null);
-        ctx.setBusy(false);
-        const s = statsFor(map);
-        ctx.appendLines({
-          kind: 'assistant',
-          text: `codemap ${sub} complete · summarized ${s.summarized} nodes`,
-        });
+        try {
+          if (sub === 'rebuild') await rebuildCodemap(ctx.cwd);
+          ctx.setCodemapProgress({ done: 0, total: 0, path: 'starting' });
+          const map = await buildSummaries(ctx.cwd, {
+            force: sub === 'rebuild',
+            signal: controller.signal,
+            onProgress: (done, total, path) =>
+              ctx.setCodemapProgress({ done, total, path }),
+          });
+          const s = statsFor(map);
+          ctx.appendLines({
+            kind: controller.signal.aborted ? 'error' : 'assistant',
+            text: controller.signal.aborted
+              ? `codemap ${sub} aborted · summarized ${s.summarized} nodes so far`
+              : `codemap ${sub} complete · summarized ${s.summarized} nodes`,
+          });
+        } finally {
+          ctx.setCodemapProgress(null);
+          ctx.setBusy(false);
+          ctx.registerAbort(null);
+        }
         return;
       }
       ctx.appendLines({
@@ -55,6 +64,7 @@ export const codemapCommand: SlashCommand = {
     } catch (e: unknown) {
       ctx.setCodemapProgress(null);
       ctx.setBusy(false);
+      ctx.registerAbort(null);
       ctx.appendLines({ kind: 'error', text: errorMessage(e) });
     }
   },

--- a/src/cli/commands/types.ts
+++ b/src/cli/commands/types.ts
@@ -10,6 +10,13 @@ export interface CommandContext {
   appendLines: (...lines: Line[]) => void;
   setBusy: (b: boolean) => void;
   setCodemapProgress: (p: CodemapProgress | null) => void;
+  /**
+   * Register (or clear with `null`) an abort callback for a long-running
+   * command. The Esc handler in App.tsx invokes the registered callback so
+   * background work — e.g. an in-flight `/codemap build` — actually stops
+   * instead of just clearing the busy flag.
+   */
+  registerAbort: (abort: (() => void) | null) => void;
   enterReconfigure: () => void;
   exit: () => void;
 }

--- a/src/codemap/summarize.ts
+++ b/src/codemap/summarize.ts
@@ -88,6 +88,9 @@ export async function summarizeCodemap(
   const recordProgress = (path: string) => {
     done += 1;
     sinceCheckpoint += 1;
+    // Skip the `onProgress` callback once aborted so a torn-down build can't
+    // keep pushing updates into the TUI after the user pressed Esc.
+    if (options.signal?.aborted) return;
     options.onProgress?.(done, total, path);
     if (checkpointEvery > 0 && sinceCheckpoint >= checkpointEvery) {
       sinceCheckpoint = 0;


### PR DESCRIPTION
## Summary
  - Fix: pressing **Esc** during `/codemap build|rebuild` now actually cancels the build instead of just clearing the busy flag while the summarization loop
   keeps running in the background.
  - The lingering loop was the root cause of two visible symptoms: (a) the `codemap · n/total · path` loader reappearing under a normal prompt, and (b) the
  next prompt failing with *"Could not connect to the model server"* because the zombie codemap was still hammering the same Ollama connection.
  - Mechanism: slash commands can now register an abort callback via a new `CommandContext.registerAbort`. The Esc handler in `App.tsx` invokes the
  registered callback before clearing UI state, so the work actually stops. `/codemap` wires an `AbortController` and threads `signal` into `buildSummaries`
   (the option already existed but wasn't being used). `recordProgress` in `summarize.ts` also short-circuits its `onProgress` callback once aborted, so an
  in-flight `summarizeFile`/`summarizeDir` call can't push another state update after the user pressed Esc.
  - On abort, the transcript now reads `codemap build aborted · summarized N nodes so far` instead of pretending it completed.

  ## Files changed
  - `src/cli/commands/types.ts` — add `registerAbort: (abort: (() => void) | null) => void` to `CommandContext`.
  - `src/cli/commands/codemap.ts` — create `AbortController`, register it, pass `signal` to `buildSummaries`, wrap in `try/finally` so
  progress/busy/registration always clear.
  - `src/cli/App.tsx` — `commandAbortRef` + `registerAbort`; Esc handler fires the registered abort first and clears `codemapProgress`; pass `registerAbort`
   into the slash-command context.
  - `src/codemap/summarize.ts` — `recordProgress` skips `onProgress`/checkpoint once `options.signal?.aborted`.
